### PR TITLE
Class fixes

### DIFF
--- a/miniprojectreport.cls
+++ b/miniprojectreport.cls
@@ -34,6 +34,8 @@
 	bottom=1in,
 	right=1in
 }
+\usepackage[none]{hyphenat}
+\sloppy
 \usepackage{setspace}
 \usepackage{tocloft}
 \usepackage{lipsum}


### PR DESCRIPTION
prevents words flowing into right margin, and and remove hyphenation in the entire document